### PR TITLE
Test trained SSD model on video files or webcam

### DIFF
--- a/ssd_testing.py
+++ b/ssd_testing.py
@@ -1,0 +1,147 @@
+"""SSD testing utils."""
+
+import cv2
+import keras
+from keras.applications.imagenet_utils import preprocess_input
+from keras.backend.tensorflow_backend import set_session
+from keras.models import Model
+from keras.preprocessing import image 
+import pickle
+import numpy as np
+from random import shuffle
+from scipy.misc import imread, imresize
+
+from ssd import SSD300 as SSD
+from ssd_training import MultiboxLoss
+from ssd_utils import BBoxUtility
+
+class VideoTest(object):
+    """ Class for testing a trained SSD model on a video file and show the
+        result in a window. Class is designed so that one VideoTest object 
+        can be created for a model, and the same object can then be used on 
+        multiple videos and webcams
+        
+        Arguments:
+            class_names: A list of strings, each containing the name of a class.
+                         The first name should be that of the background class
+                         which is not used.
+                         
+            model:       An SSD model. It is expected to be already trained and 
+                         compiled before used as input here.
+                         
+            input_shape: The shape that the model expects for its input, 
+                         as a tuple (i.e. (300, 300))                          
+    
+    """
+    
+    def __init__(self, class_names, model, input_shape):
+        self.class_names = class_names
+        self.num_classes = len(class_names)
+        self.model = model
+        self.input_shape = input_shape
+        
+        # Create unique and somewhat visually distinguishable colors for classes    
+        self.class_colors = []
+        for i in range(0, self.num_classes):
+            # This can probably be written in a more elegant manner
+            lin = 255*i/self.num_classes
+            col = np.zeros((1,1,3)).astype("uint8")
+            col[0][0][0] = lin
+            col[0][0][1] = 128
+            col[0][0][2] = 255
+            cvcol = cv2.cvtColor(col, cv2.COLOR_HSV2BGR)
+            col = (int(cvcol[0][0][0]), int(cvcol[0][0][1]), int(cvcol[0][0][2]))
+            self.class_colors.append(col) 
+        
+    def run(self, video_path = 0, start_frame = 0, conf_thresh = 0.6):
+        """ Runs the test on a video (or webcam)
+        
+        # Arguments
+        video_path: A file path to a video to be tested on. Can also be a number, 
+                    in which case the webcam with the same number (i.e. 0) is 
+                    used instead
+                    
+        start_frame: The number of the first frame of the video to be processed
+                     by the network. 
+                     
+        conf_thresh: Threshold of confidence. Any boxes with lower confidence 
+                     are not visualized.
+                    
+        """
+    
+        vid = cv2.VideoCapture(video_path)
+        if not vid.isOpened():
+            raise IOError(("Couldn't open video file or webcam. If you're "
+            "trying to open a webcam, make sure you video_path is an integer!")
+        
+        # Compute aspect ratio of video     
+        vidw = vid.get(cv2.cv.CV_CAP_PROP_FRAME_WIDTH)
+        vidh = vid.get(cv2.cv.CV_CAP_PROP_FRAME_HEIGHT)
+        vidar = vidw/vidh
+        
+        # Skip frames until reaching start_frame
+        if start_frame > 0:
+            vid.set(cv2.cv.CV_CAP_PROP_POS_MSEC, start_frame)
+            
+        while True:
+            retval, orig_image = vid.read()
+            if not retval:
+                print("Done!")
+                return
+                
+            resized = cv2.resize(orig_image, self.input_shape)
+            rgb = cv2.cvtColor(resized, cv2.COLOR_BGR2RGB)
+            
+            # Reshape to original aspect ratio for later visualization
+            # The resized version is used, to visualize what kind of resolution
+            # the network has to work with.
+            to_draw = cv2.resize(resized, (int(self.input_shape[0]*vidar), self.input_shape[1]))
+            
+            # Use model to predict 
+            inputs = [image.img_to_array(rgb)]
+            tmp_inp = np.array(inputs)
+            x = preprocess_input(tmp_inp)
+            y = model.predict(x)
+            
+            results = bbox_util.detection_out(y)
+            
+            # Interpret output, only one frame is used 
+            i=0
+            det_label = results[i][:, 0]
+            det_conf = results[i][:, 1]
+            det_xmin = results[i][:, 2]
+            det_ymin = results[i][:, 3]
+            det_xmax = results[i][:, 4]
+            det_ymax = results[i][:, 5]
+            
+            top_indices = [i for i, conf in enumerate(det_conf) if conf >= conf_thresh]
+            
+            top_conf = det_conf[top_indices]
+            top_label_indices = det_label[top_indices].tolist()
+            top_xmin = det_xmin[top_indices]
+            top_ymin = det_ymin[top_indices]
+            top_xmax = det_xmax[top_indices]
+            top_ymax = det_ymax[top_indices]
+            
+            for i in range(top_conf.shape[0]):
+                xmin = int(round(top_xmin[i] * to_draw.shape[1]))
+                ymin = int(round(top_ymin[i] * to_draw.shape[0]))
+                xmax = int(round(top_xmax[i] * to_draw.shape[1]))
+                ymax = int(round(top_ymax[i] * to_draw.shape[0]))
+                
+                # Draw the box on top of the to_draw image
+                class_num = int(top_label_indices[i])
+                cv2.rectangle(to_draw, (xmin, ymin), (xmax, ymax), 
+                              self.class_colors[class_num], 3)
+                text = self.class_names[class_num] + " " + ('%.2f' % top_conf[i])
+                
+                text_top = (xmin, ymin-2)
+                text_bot = (xmin + 110, ymin + 20)
+                text_pos = (xmin + 5, ymin + 15)
+                cv2.rectangle(to_draw, text_top, text_bot, self.class_colors[class_num], -1)
+                cv2.putText(to_draw, text, text_pos, cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0,0,0), 1)
+            
+            cv2.imshow("SSD result", to_draw)
+            cv2.waitKey(10)
+            
+        

--- a/testing_utils/videotest.py
+++ b/testing_utils/videotest.py
@@ -1,4 +1,4 @@
-"""SSD testing utils."""
+""" A class for testing a SSD model on a video file or webcam """
 
 import cv2
 import keras
@@ -12,9 +12,10 @@ from random import shuffle
 from scipy.misc import imread, imresize
 from timeit import default_timer as timer
 
-from ssd import SSD300 as SSD
-from ssd_training import MultiboxLoss
+import sys
+sys.path.append("..")
 from ssd_utils import BBoxUtility
+
 
 class VideoTest(object):
     """ Class for testing a trained SSD model on a video file and show the
@@ -40,12 +41,12 @@ class VideoTest(object):
     
     """
     
-    def __init__(self, class_names, model, input_shape, bbox_util):
+    def __init__(self, class_names, model, input_shape):
         self.class_names = class_names
         self.num_classes = len(class_names)
         self.model = model
         self.input_shape = input_shape
-        self.bbox_util = bbox_util
+        self.bbox_util = BBoxUtility(self.num_classes)
         
         # Create unique and somewhat visually distinguishable bright
         # colors for the different classes.

--- a/testing_utils/videotest_example.py
+++ b/testing_utils/videotest_example.py
@@ -1,0 +1,20 @@
+import keras
+import pickle
+from videotest import VideoTest
+
+import sys
+sys.path.append("..")
+from ssd import SSD300 as SSD
+
+input_shape = (300,300,3)
+class_names = ["background", "spam", "eggs", "ham"] 
+NUM_CLASSES = len(class_names)
+
+model = SSD(input_shape, num_classes=NUM_CLASSES)
+model.load_weights('path/to/trained/weights-file.h5')
+        
+vid_test = VideoTest(class_names, model, input_shape)
+
+# To test on webcam 0, remove the parameter (or change it to another number
+# to test on that webcam)
+vid_test.run('path/to/your/video.mkv')


### PR DESCRIPTION
Adds a python script called ssd_testing.py, which is meant to contain various utilities for testing trained SSD models. It currently contains a VideoTest, which can be used to run the SSD model on a video file or a webcam (similar to ssd_pascal_video.py in the original Caffe implementation of SSD). It shows the result in an OpenCV window, with the boxes, their class names and the confidence. It also shows the frames-per-second which can be useful to measure performance. 

The VideoTest class is designed to be easy to use. Simply load your model, load its weights, and create a VideoTest for the model. Then that test can be run on one or many videos and/or webcams. It can be used something like this:

```
import keras
import pickle
from ssd_testing import VideoTest
from ssd import SSD300 as SSD
from ssd_utils import BBoxUtility

input_shape = (300,300,3)
class_names = ["background", "your", "other", "class", "names"] 
num_classes = len(class_names)

priors = pickle.load(open('prior_boxes_ssd300.pkl', 'rb'))
bbox_util = BBoxUtility(num_classes, priors)

model = SSD(input_shape, num_classes=num_classes)
model.load_weights('path/to/your/weights.h5')
        
vid_test = VideoTest(class_names, model, input_shape, bbox_util)
vid_test.run('path/to/your/video.mkv')
```