### PR TITLE
Fix bug from covariance matrix returning complex eigenvectors

### DIFF
--- a/SSD_training.ipynb
+++ b/SSD_training.ipynb
@@ -158,7 +158,7 @@
     "\n",
     "    def lighting(self, img):\n",
     "        cov = np.cov(img.reshape(-1, 3) / 255.0, rowvar=False)\n",
-    "        eigval, eigvec = np.linalg.eig(cov)\n",
+    "        eigval, eigvec = np.linalg.eigh(cov)\n",
     "        noise = np.random.randn(3) * self.lighting_std\n",
     "        noise = eigvec.dot(eigval * noise) * 255\n",
     "        img += noise\n",
@@ -517,21 +517,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda root]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-root-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hello,
Thanks @rykov8  for making available the code. I was training the VOC2007 dataset and I encountered that the eigenvectors from the covariance matrix were complex. Since the covariance matrix is symmetrical we can use `np.linalg.eigh` which is intended for the specific case of symmetrical matrices (and returns only reals).

Also, I made a XML parser for VOC I can make a pull request for this or simply put it in a gist, you tell me if you want it here. 

Thank you! 